### PR TITLE
add newline before command separator

### DIFF
--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -100,7 +100,7 @@ class _BashSession:
         # send command to the process
         self._process.stdin.write(
             command.encode()
-            + f"{command_sep} echo {self._sentinel.replace('__ERROR_CODE__', errcode_retriever)}\n".encode()
+            + f"\n{command_sep} echo {self._sentinel.replace('__ERROR_CODE__', errcode_retriever)}\n".encode()
         )
         await self._process.stdin.drain()
 


### PR DESCRIPTION
Add newline before command separator.

Some models may use heredoc, such as
```bash
python - << 'EOF'
... (some python code here)
EOF
```

The last line needs to be exact the delimiter w/o other symbols.

## Description

<!-- Add a brief description about this pull request including what it does, why it is needed, and other important information for the reviewers -->

## More Information

<!-- Add more in-depth information about this pull request, such as the changes made, the reasoning behind them, and any potential impacts. -->

## Validation

<!-- Introduce how to test this pull request. -->

## Linked Issues

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
